### PR TITLE
"expose" Attribute

### DIFF
--- a/compose/attribute.go
+++ b/compose/attribute.go
@@ -43,8 +43,15 @@ func InitServicesAttributes() []Attribute {
 		},
 		{
 			Name:             "ports",
-			InputDescription: "Expose ports",
+			InputDescription: "Expose ports, publish/map to host (HOST_PORT:CONTAINER_PORT)",
 			Example:          "8000:8000",
+			IsList:           true,
+			Category:         servicesCategory,
+		},
+		{
+			Name:             "expose",
+			InputDescription: "Expose ports, not published/mapped to host",
+			Example:          "8000",
 			IsList:           true,
 			Category:         servicesCategory,
 		},


### PR DESCRIPTION
* Update attribute.go

Add "expose" attribute to expose ports within Docker and not published/mapped to the host. Updated description of "ports" attribute to differentiate from "expose".